### PR TITLE
Add NTP lib.

### DIFF
--- a/lib/ntp.py
+++ b/lib/ntp.py
@@ -12,7 +12,7 @@ import machine
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
 # With Mk3 Firmware an IP address string works 5%, hangs at socket.socket(..) 95%, could be a bug in 2016 upython?
-NTP_HOSTS = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]
+NTP_HOSTS = ["ntp-gps.emf.camp", "0.emfbadge.pool.ntp.org", "1.emfbadge.pool.ntp.org", "2.emfbadge.pool.ntp.org", "3.emfbadge.pool.ntp.org"]
 NTP_PORT = 123
 
 def get_NTP_time():


### PR DESCRIPTION
An implementation of SNTP, derived from the Mk3-Firmware implementation. Could be added to a post-wifi-connect hook once well-tested.

Changes from Mk3-Firmware:
- Catch exception when DNS lookup fails.
- Handle KoD response.
- Add multiple host failover.

TODO before merging:
- [x] Run/Test on Mk3 Badge / Firmware.
- [x] Run/Test on Mk4 Badge / Firmware.
- ~~[ ] Test using IP Address strings with Mk4 Firmware, see line 13.~~
- [x] Use onsite NTP server as primary (need hostname/IP from NOC).
- [x] Use NTP Pool vendor zone as secondaries (https://www.ntppool.org/vendors.html)