### PR TITLE
added /dev/tty.usbmodemTiLDA* to glob paths in find_tty

### DIFF
--- a/.development/pyboard_util.py
+++ b/.development/pyboard_util.py
@@ -62,7 +62,7 @@ def soft_reset(args, verbose = True):
 
 def find_tty():
     # Todo: find solution for windows, test in linux
-    for pattern in ['/dev/ttyACM*', '/dev/tty.usbmodem*']:
+    for pattern in ['/dev/ttyACM*', '/dev/tty.usbmodemTiLDA*', '/dev/tty.usbmodem*']:
         for path in glob.glob(pattern):
             return path
     print("Couldn't find badge tty - Please make it's plugged in and reset it if necessary")


### PR DESCRIPTION
On my Mac at least, the Mk4 badge appears as `/dev/tty.usbmodemTiLDA2`, and a couple of other things as `/dev/tty.usbmodem*`, so find_tty() never succeeds - it hits another thing before the tilda.

This patch adds the more specifc `/dev/tty.usbmodemTiLDA2` to the glob search paths, which should fix the issue without causing a regression.