### PR TITLE
firmware-update.py: Use py3.6 compatible arguments to subprocess.run()

### DIFF
--- a/.development/firmware_update.py
+++ b/.development/firmware_update.py
@@ -10,7 +10,7 @@ def firmware_update(verbose):
 
     print("Hello - Welcome to the automated TiLDA Mk4 firmware updater")
     try:
-        response = subprocess.run(["dfu-util", "--list"], capture_output=True)
+        response = subprocess.run(["dfu-util", "--list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if response.returncode != 0:
             print(response)
             return


### PR DESCRIPTION
Replacement for #29, fixing for Python3.6 (default in Ubuntu 18.04).

TODO:
- [ ] Test all possible tilda-tools commands