### PR TITLE
Fix homescreen name database key

### DIFF
--- a/settings/main.py
+++ b/settings/main.py
@@ -35,7 +35,7 @@ def settings_wifi(state):
 
 def settings_main(state):
     return selection({
-        "Homescreen Name": change_database_string("Set your name", "name"),
+        "Homescreen Name": change_database_string("Set your name", "homescreen.name"),
         "Wifi": settings_wifi,
         "Startup app": settings_startup_app,
         "Badge Store": settings_badge_store


### PR DESCRIPTION
Looking at the homescreen code, I think the key should be `homescreen.name` not just `name`. Unfortunately I’ve not worked out yet how to test this, so YMMV.