### PR TITLE
tilda_tools - Fix "'charmap' codec can't decode byte 0x9d" on windows for validate, sync, run

### DIFF
--- a/.development/pyboard_util.py
+++ b/.development/pyboard_util.py
@@ -81,7 +81,7 @@ def find_tty():
 
 def check_run(paths):
     for filename in paths:
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf8') as f:
             pyfile = f.read()
             compile(pyfile + '\n', filename, 'exec')
 

--- a/.development/resources.py
+++ b/.development/resources.py
@@ -141,7 +141,6 @@ def add_metadata(path, resources):
 
         if file:
             try:
-                print(os.path.join(path, file))
                 with open(os.path.join(path, file), "r", encoding='utf8') as stream:
                     resource.update(_normalize_metadata(read_metadata(stream)))
             except ParseException as e:

--- a/.development/resources.py
+++ b/.development/resources.py
@@ -141,7 +141,8 @@ def add_metadata(path, resources):
 
         if file:
             try:
-                with open(os.path.join(path, file), "r") as stream:
+                print(os.path.join(path, file))
+                with open(os.path.join(path, file), "r", encoding='utf8') as stream:
                     resource.update(_normalize_metadata(read_metadata(stream)))
             except ParseException as e:
                 resource.setdefault("errors", []).append(file + ": " + str(e))
@@ -197,7 +198,7 @@ def _validate_resource(path, resource):
         if file.endswith(".py"):
             try:
                 filename = os.path.join(path, file)
-                with open(filename, 'r') as s:
+                with open(filename, 'r', encoding='utf8') as s:
                     compile(s.read() + '\n', filename, 'exec')
             except Exception as e:
                 resource.setdefault("errors", []).append(str(e))


### PR DESCRIPTION
By default python on windows was treating files being opened by tilda_tools as being CP1252 encoded. This fix forces UTF8 for 3 commands (validate, sync, run)