### PR TITLE
fix get address info for IPv4 addresses

### DIFF
--- a/lib/http.py
+++ b/lib/http.py
@@ -199,10 +199,7 @@ def open_http_socket(method, url, json=None, timeout=None, headers=None, data=No
 
 def get_address_info(host, port, retries_left = 20):
     try:
-        if is_ipv4_address(host):
-            return (host, port)
-        else:
-            return usocket.getaddrinfo(host, port)[0][4]
+        return usocket.getaddrinfo(host, port)[0][4]
     except OSError as e:
         if ("-15" in str(e)) and retries_left:
             # [addrinfo error -15]

--- a/lib/http.py
+++ b/lib/http.py
@@ -200,7 +200,7 @@ def open_http_socket(method, url, json=None, timeout=None, headers=None, data=No
 def get_address_info(host, port, retries_left = 20):
     try:
         if is_ipv4_address(host):
-            addr = (host, port)
+            return (host, port)
         else:
             return usocket.getaddrinfo(host, port)[0][4]
     except OSError as e:
@@ -268,5 +268,3 @@ def is_ipv4_address(address):
         return len(valid_octets) == 4
     except Exception:
         return False
-
-


### PR DESCRIPTION
Not sure if this was an optimisation or something, but I was getting a `object with buffer protocol required` error when requesting an IPv4 address like `http://94.45.245.124:8090/ipfs/QmXLTsNgF3ZjFAtbHh6qnhKGw6HtmniNhZzWbq2tMLYJ5x`.

Solution seemed to be to just use `getaddrinfo` always:

> `getaddrinfo` function, which must be used to resolve textual address (**including numeric addresses**)

http://docs.micropython.org/en/latest/pyboard/library/usocket.html#socket-address-format-s