### PR TITLE
Make Holland a non-bootstrapped app

### DIFF
--- a/holland/main.py
+++ b/holland/main.py
@@ -4,7 +4,7 @@ ___name___         = "Holland"
 ___license___      = "MIT"
 ___dependencies___ = ["app", "sim800", "ugfx_helper"]
 ___categories___   = ["Villages"]
-___bootstrapped___ = True
+___bootstrapped___ = False
 
 from app import *
 from dialogs import *


### PR DESCRIPTION
Sorry if I'm just barking up the wrong tree 😛. But my app is failing to do the initial install with error 28, which is apparently "flash storage is full"; and I'm wondering whether this might be related to it trying to install Holland as part of its bootstrapped apps, but doesn't have the required 400kB?