### PR TITLE
Add warning prompt to mass_storage

### DIFF
--- a/mass_storage/main.py
+++ b/mass_storage/main.py
@@ -11,12 +11,18 @@ import ugfx, tilda, ugfx_helper, dialogs, app, time
 ugfx_helper.init()
 ugfx.clear()
 
-print("enabling USB storage...")
-tilda.storage_enable_usb()
-time.sleep(1)
-print("DONE")
-with dialogs.WaitingMessage(title="Mass Storage Enabled", text="You can now use the badge like a USB key.\nPlease safely eject afterwards. This app will close automatically."):
-    print("Waiting for USB mass storage to be unmounted...")
-    tilda.storage_disable_usb()
+user_agreed = dialogs.prompt_boolean("Note: enabling mass storage is slightly risky, as the badge may end up factory "
+                                     "resetting even if you safely eject it. Do you want to continue?")
+
+if user_agreed:
+    print("enabling USB storage...")
+    tilda.storage_enable_usb()
+    time.sleep(1)
     print("DONE")
+    with dialogs.WaitingMessage(title="Mass Storage Enabled", text="You can now use the badge like a USB key.\nPlease safely eject afterwards. This app will close automatically."):
+        print("Waiting for USB mass storage to be unmounted...")
+        tilda.storage_disable_usb()
+        print("DONE")
+        app.restart_to_default()
+else:
     app.restart_to_default()


### PR DESCRIPTION
Enabling mass storage and then clicking Eject has caused my badge to factory-reset twice (while working fine 4 or so times), so a warning might be helpful.