### PR TITLE
Allow default launcher to be changed

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -2,7 +2,7 @@
 
 ___title___        = "Launcher"
 ___license___      = "MIT"
-___categories___   = ["System"]
+___categories___   = ["System", "Launcher"]
 ___dependencies___ = ["dialogs", "app", "ugfx_helper"]
 ___launchable___   = False
 ___bootstrapped___ = True

--- a/lib/homescreen.py
+++ b/lib/homescreen.py
@@ -51,7 +51,13 @@ def sleep_or_exit(interval = 0.5):
     # todo: do this better - check button multiple times and sleep for only a short while
     if buttons.is_triggered(tilda.Buttons.BTN_Menu):
         clean_up()
-        App("launcher").boot()
+        launcher = "launcher"
+        try:
+            with open("default_launcher.txt", "r") as dl:
+                launcher=dl.readline()
+        except OSError:
+            pass
+        App(launcher).boot()
     sleep.sleep(interval)
 
 

--- a/settings/main.py
+++ b/settings/main.py
@@ -33,12 +33,19 @@ def settings_startup_app(state):
 def settings_wifi(state):
     wifi.choose_wifi()
 
+def settings_launcher(state):
+    apps = app.get_apps("Launcher")
+    selection = prompt_option([{"title": a.title, "app": a} for a in apps], text="Select App:", none_text="Back", title="Set default launcher")
+    if selection:
+       app.write_launch_file(selection["app"].name, "default_launcher.txt")
+
 def settings_main(state):
     return selection({
         "Homescreen Name": change_database_string("Set your name", "homescreen.name"),
         "Homescreen Callsign": change_database_string("Set your callsign", "homescreen.callsign"),
         "Wifi": settings_wifi,
         "Startup app": settings_startup_app,
+        "Default Launcher": settings_launcher,
         "Badge Store": settings_badge_store
     }, none_text="Exit")
 

--- a/speedlauncher/main.py
+++ b/speedlauncher/main.py
@@ -2,7 +2,7 @@
 
 ___name___         = "Speed Launcher"
 ___license___      = "WTFPL"
-___categories___   = ["System"]
+___categories___   = ["System", "Launcher"]
 ___dependencies___ = ["app", "ugfx_helper"]
 ___launchable___   = False
 ___bootstrapped___ = False


### PR DESCRIPTION
This allows e.g. speedlauncher to be used with any of the homescreen apps.

* Create a new app category - Launcher - and add that tag to the existing two launcher apps
* Add a settings window allowing any app in that category to be written to `default_launcher.txt`
* In `/lib/homescreen.py` - if `default_launcher.txt` exists, read contents and launch as an app
