### PR TITLE
Call /update instead of /install on the backend when updating apps

### DIFF
--- a/badge_store/main.py
+++ b/badge_store/main.py
@@ -74,7 +74,7 @@ def show_update():
     if update:
         clear()
         with WaitingMessage(title=title, text="Please wait...") as message:
-            installers = store.install(_get_current_apps())
+            installers = store.update(_get_current_apps())
             n = len(installers)
             for i, installer in enumerate(installers):
                 message.text = "%s (%s/%s)" % (installer.path, i + 1, n)

--- a/lib/badge_store.py
+++ b/lib/badge_store.py
@@ -34,6 +34,9 @@ class BadgeStore:
     def install(self, apps):
         return self._create_installers(self._call("install", {"apps": ",".join(apps)}))
 
+    def update(self, apps):
+        return self._create_installers(self._call("update", {"apps": ",".join(apps)}))
+
     def bootstrap(self):
         return self._create_installers(self._call("bootstrap"))
 


### PR DESCRIPTION
The badge has no way of knowing whether an installed app came from the
badge store or local development, so simply requests all installed apps
when doing an update. The default /install path on the backend will
return a 404 if any of the requested apps aren't in the repo.

This commit calls /update instead, which doesn't 404 if an app is
missing.

Depends on emfcamp/Mk4-Backend#2

Fixes #57