### PR TITLE
Fix database.py docstring

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -6,7 +6,7 @@ Values can be anything json can store, including a dict
 Usage:
 
 import database
-with database.open() as db:
+with database.Database() as db:
     print(db.get("hello", "default"))
     db.set("foo", "world")
     db.delete("bar")


### PR DESCRIPTION
The docstring incorrectly specified `database.open()` as the method to acquire a database context, but the method was not present in the module. Instead, it'll tell people to just create a database object directly.