### PR TITLE
Fix bootstrapped apps filter when no path specified

### DIFF
--- a/.development/tilda_tools.py
+++ b/.development/tilda_tools.py
@@ -124,8 +124,11 @@ def main():
         paths = args.paths if len(args.paths) else None
         if args.bootstrapped_apps:
             for k,val in list(resources.items()):
+                requested = paths and k in paths
+                bootstrapped = val.get("bootstrapped", False)
                 if val.get("type", None) == "app":
-                    if not k in paths and not val.get("bootstrapped", False):
+                    if not (bootstrapped or (paths and requested)):
+                        # App is not in the bootstrap list, and isn't explicitly requested
                         if args.verbose:
                             print("Removing app '{0}' from sync list".format(k))
                         del resources[k]


### PR DESCRIPTION
Fixes a bug in the --bootstrapped-apps handling:
```
> ./tilda_tools --bootstrapped-apps sync
Local Test: PASS
Connected to badge: DONE
Stopping running app: DONE
Traceback (most recent call last):
  File "./tilda_tools", line 160, in <module>
    main()
  File "./tilda_tools", line 128, in main
    if not k in paths and not val.get("bootstrapped", False):
TypeError: argument of type 'NoneType' is not iterable
```
Fix: Explicitly check if paths is set when checking if an app has been requested for sync and again when removing apps from the resources list/queue.