### PR TITLE
Set bootstrapped = False on two apps that don't need to be.

### DIFF
--- a/home_pycon/main.py
+++ b/home_pycon/main.py
@@ -1,4 +1,4 @@
-"""Default homescreen
+"""PyCon homescreen
 
 This is the default homescreen for the Tilda Mk4.
 It gets automatically installed when a badge is
@@ -10,7 +10,7 @@ ___license___      = "MIT"
 ___categories___   = ["Homescreens"]
 ___dependencies___ = ["homescreen"]
 ___launchable___   = False
-___bootstrapped___ = True
+___bootstrapped___ = False
 
 import ugfx
 from homescreen import *

--- a/orbs/main.py
+++ b/orbs/main.py
@@ -5,7 +5,7 @@ ___name___         = "Orbs Game"
 ___license___      = "MIT"
 ___dependencies___ = ["app", "dialogs", "sim800", "ugfx_helper"]
 ___categories___   = ["Games"]
-___bootstrapped___ = True
+___bootstrapped___ = False
 
 from app import *
 from dialogs import *


### PR DESCRIPTION
 - home_pycon: Home screen for PyCon, not relevent to most EMF users
 - orbs: Game no longer usable after EMF as server is offline

While here, correct comment in home_pycon explaining what it is.