### PR TITLE
Added backlight dimming to homescreens.

### DIFF
--- a/lib/homescreen.py
+++ b/lib/homescreen.py
@@ -19,9 +19,8 @@ They also *may*:
 ___license___      = "MIT"
 ___dependencies___ = ["database", "buttons", "app", "sleep", "ugfx_helper", "wifi", "sim800"]
 
-import database, ugfx, random, buttons, tilda, sleep, ugfx_helper, wifi, time, sim800
+import database, ugfx, random, buttons, tilda, sleep, ugfx_helper, wifi, time, sim800, machine, math
 from app import App
-
 _state = None
 def init(enable_menu_button = True):
     global _state
@@ -58,6 +57,11 @@ def sleep_or_exit(interval = 0.5):
         except OSError:
             pass
         App(launcher).boot()
+
+    # Adjust backlight to save power
+    backlight = max(min(tilda.Sensors.get_lux(), 99), 1)
+    machine.PWM(machine.PWM.PWM_LCDBL).duty(math.floor(backlight))
+
     sleep.sleep(interval)
 
 


### PR DESCRIPTION
Hey, something small I cooked up while tinkering with my badge!

Added automatic backlight adjustment to homescreens using the lux sensor to save power, since badges spend most of their time displaying a homescreen. This should work with any homescreen which uses `lib/homescreen.py`!